### PR TITLE
Update AntivirusDeployment.yaml

### DIFF
--- a/AntivirusDeployment.yaml
+++ b/AntivirusDeployment.yaml
@@ -122,13 +122,13 @@ Resources:
           inputs:
             runCommand:
             - !Sub |
-                #!/bin/bash
-                set -e
-                if ! rpm -qi cybereason-sensor-${AVVersionLinux}-1 --quiet; then
-                  agentPath='/tmp/cybereasonInstall/'
-                  aws s3 cp s3://cybereasonsensor/Linux/cybereason-sensor-${AVVersionLinux}-1.x86_64_tamedia_tamedia-r.cybereason.net_443_ACTIVE_NORMAL_rpm.rpm $agentPath
-                  rpm -Uhv $agentPath/cybereason-sensor-${AVVersionLinux}-1.x86_64_tamedia_tamedia-r.cybereason.net_443_ACTIVE_NORMAL_rpm.rpm
-                  rm -rf $agentPath
+                #!/bin/bash 
+                set -e 
+                if ! yum info cybereason-sensor-${AVVersionLinux}-1 >/dev/null 2>&1; then
+                  agentPath='/tmp/cybereasonInstall/' 
+                  aws s3 cp s3://cybereasonsensor/Linux/cybereason-sensor-${AVVersionLinux}-1.x86_64_tamedia_tamedia-r.cybereason.net_443_ACTIVE_NORMAL_rpm.rpm $agentPath 
+                  yum install -y $agentPath/cybereason-sensor-${AVVersionLinux}-1.x86_64_tamedia_tamedia-r.cybereason.net_443_ACTIVE_NORMAL_rpm.rpm 
+                  rm -rf $agentPath 
                 fi
   CybereasonDocumentAssociation:
     Type: AWS::SSM::Association


### PR DESCRIPTION
Changed the way we deploy Linux sensor.
We now use yum instead of rpm as requested by Alfredo Gottardo because it was creating rpm db corruption.